### PR TITLE
Add publishing information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
+### greenfoot ###
+# Greenfoot: A BlueJ-based game IDE for programming beginners. http://bluej.org
+
+# Editor preferences for a class etc, see http://lists.bluej.org/pipermail/bluej-discuss/2003-May/002351.html
+*.ctxt
+
+# Project file. Continously checking it in destroys the project ocasionally (while merging etc.) because it changes completely at every compile. Instead, make a copy of the file after the first runtime and name it e.g. `project.example.greenfoot`. See http://bugs.bluej.org/greenfoot/ticket/409
+
+project.greenfoot
+
+### Java ###
 # Compiled class file
 *.class
 
@@ -5,7 +16,6 @@
 *.log
 
 # BlueJ files
-*.ctxt
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
@@ -21,3 +31,28 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+### Windows ###
+# Windows thumbnail cache files
+Thumbs.db
+ehthumbs.db
+ehthumbs_vista.db
+
+# Dump file
+*.stackdump
+
+# Folder config file
+[Dd]esktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msix
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk

--- a/README.TXT
+++ b/README.TXT
@@ -53,11 +53,13 @@ PUSHING INSTRUCTIONS:
 
 	git checkout -b [name]
 
-2) Add and commit all your changes
+2) Add and commit all changes
 
 	git add -A
 	git commit -m "[name] commit"
 
 3) Push your changes to your new branch, enter login credentials if prompted
 
-	git push
+	git push --set-upstream origin [name]
+
+4) Your changes are now published on a new branch. Wait for them to be merged by the build master.

--- a/README.TXT
+++ b/README.TXT
@@ -62,4 +62,6 @@ PUSHING INSTRUCTIONS:
 
 	git push --set-upstream origin [name]
 
-4) Your changes are now published on a new branch. Wait for them to be merged by the build master.
+4) Your changes are now published on a new branch. Open the repository on GitHub.com, and click the branch: master button. Select your branch name in the dropdown. After this, click the New Pull Request button immediately to its right. On the new page, click new Pull Request, and it will be merged by the Build Master.
+
+	Video demoing this process: https://my.mixtape.moe/kujlwv.webm

--- a/README.TXT
+++ b/README.TXT
@@ -47,3 +47,17 @@ git commit -m “adding my files to the repository”
 
 8) Push your changes to the remote repository:
 
+PUSHING INSTRUCTIONS:
+
+1) Create a new branch for your changes. Replace [name] with your last name
+
+	git checkout -b [name]
+
+2) Add and commit all your changes
+
+	git add -A
+	git commit -m "[name] commit"
+
+3) Push your changes to your new branch, enter login credentials if prompted
+
+	git push

--- a/README.TXT
+++ b/README.TXT
@@ -47,7 +47,7 @@ git commit -m “adding my files to the repository”
 
 8) Push your changes to the remote repository:
 
-PUSHING INSTRUCTIONS:
+PERIOD 3 PUBLISHING INSTRUCTIONS:
 
 1) Create a new branch for your changes. Replace [name] with your last name
 


### PR DESCRIPTION
Don't merge yet.

- [x] Added Greenfoot and windows quirks to the gitignore.
- [ ] Default `project.greenfoot` created from a clean compile. I'll fix this tonight if I have time or otherwise I'll stash my chages in class and fix this, probably shouldn't merge this PR until this is completed.
- [x] Added period 3 publishing instructions with a video demo (hence #2). I'm not sure how period 2 is going to do this, we should at least work on separate branches, maybe even separate forks? The publishing instructions will probably vary after this has been changed but as the build master I think this is the easiest workflow for the class to use.